### PR TITLE
Use relayer sdk bundle

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,8 +20,7 @@
     <meta name="twitter:title" content="GM Contract Interface" />
     <meta name="twitter:description" content="A modern, privacy-focused GM smart contract interface" />
     
-    <!-- Zama FHE SDK - UMD CDN -->
-    <script src="https://cdn.zama.ai/relayer-sdk-js/0.1.0-9/relayer-sdk-js.umd.cjs" type="text/javascript"></script>
+    <!-- Zama SDK bundle được đóng gói cùng ứng dụng qua Vite -->
   </head>
   <body>
     <div id="root"></div>

--- a/src/utils/zamaSDK.ts
+++ b/src/utils/zamaSDK.ts
@@ -1,3 +1,4 @@
+import { initSDK, createInstance, SepoliaConfig } from '@zama-fhe/relayer-sdk/bundle';
 import { ethers } from 'ethers';
 
 let instance: any = null;
@@ -7,13 +8,8 @@ export async function initializeZamaSDK() {
   if (instance) return instance;
   
   try {
-    // Get SDK from window object (loaded via UMD CDN script tag)
-    const sdk = (window as any).relayerSDK;
-    if (!sdk) {
-      throw new Error('Zama SDK not found in window object. Make sure UMD CDN script is loaded.');
-    }
-    
-    const { initSDK, createInstance, SepoliaConfig } = sdk;
+    // Load WASM & SDK (bundle version) — no global needed
+    // initSDK & createInstance come from the ESM bundle import
     
     // Step 1: Load WASM first with retry
     let retryCount = 0;


### PR DESCRIPTION
Switch Zama FHE Relayer SDK usage from UMD CDN to `@zama-fhe/relayer-sdk/bundle` as requested.

---
<a href="https://cursor.com/background-agent?bcId=bc-615b27c6-b073-40d9-aaeb-bb09f31cd1e7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-615b27c6-b073-40d9-aaeb-bb09f31cd1e7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>